### PR TITLE
Update SQL README for course to-do list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # skills-data-engineer
+
+This repository contains SQL instructions for managing a simple course to-do list. The `sql` directory holds scripts and documentation.

--- a/sql/Readme.md
+++ b/sql/Readme.md
@@ -1,1 +1,40 @@
-test
+# SQL To-Do List for Course
+
+This directory contains SQL instructions for building a minimal to-do list to track course tasks.
+
+## Table Creation
+
+```sql
+CREATE TABLE tasks (
+    id SERIAL PRIMARY KEY,
+    description TEXT NOT NULL,
+    due_date DATE,
+    completed BOOLEAN DEFAULT FALSE
+);
+```
+
+## Example Usage
+
+Insert a new task:
+
+```sql
+INSERT INTO tasks (description, due_date)
+VALUES ('Finish lesson 1 readings', '2023-08-15');
+```
+
+Mark a task as completed:
+
+```sql
+UPDATE tasks
+SET completed = TRUE
+WHERE id = 1;
+```
+
+List incomplete tasks:
+
+```sql
+SELECT id, description, due_date
+FROM tasks
+WHERE completed = FALSE
+ORDER BY due_date;
+```


### PR DESCRIPTION
## Summary
- update root README with brief repo description
- add details to `sql/Readme.md` describing how to create and manage a course to-do list using SQL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b333d793083308fc768c35958583f